### PR TITLE
convert to using SVG path tag

### DIFF
--- a/run.php
+++ b/run.php
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+include 'src/QRCode.php';
+
+use splitbrain\phpQRCode\QRCode;
+
+if(count($argv) < 3){
+
+    echo "Missing argument!\n";
+    exit(1);
+
+}else{
+
+    $qrcode = QRCode::svg($argv[1]);
+    file_put_contents($argv[2], $qrcode);
+    exit(0);
+
+}
+
+?>

--- a/src/QRCode.php
+++ b/src/QRCode.php
@@ -71,15 +71,17 @@ class QRCode
     {
         $code = $this->dispatch_encode($this->data, $this->options);
         $svg = sprintf('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d">', $code['s'][0], $code['s'][1]);
+        $path = '<path d="';
         foreach ($code['b'] as $y => $row) {
             foreach ($row as $x => $val) {
                 if ($val) {
-                    $svg .= sprintf('<rect x="%d" y="%d" width="1" height="1" />', $x, $y);
+                    $path .= sprintf("M%d,%d L%d,%d %d,%d %d,%d Z ", $x, $y, ($x+1), $y, ($x+1), ($y+1), $x, ($y+1)); 
                 }
             }
         }
+        $path .= '" fill="black" />';
+        $svg .= $path;
         $svg .= '</svg>';
-
         return $svg;
     }
 


### PR DESCRIPTION
I have converted the SVG from using <rect /> to <path />. This change opens up possibilities for parsing using [PathParser](https://developer.android.com/reference/kotlin/androidx/core/graphics/PathParser) on Android and allows for the addition of images. Additionally, I have created a simple script to generate QR Codes in the terminal.